### PR TITLE
Reset restart requested

### DIFF
--- a/mu_semtech/delta.py
+++ b/mu_semtech/delta.py
@@ -1,20 +1,17 @@
 from sparql import Triple
 
 
-class DeltaInsert(Triple):
-    pass
-
-class DeltaDelete(Triple):
-    pass
-
 class UpdateData:
     def __init__(self, data):
         assert isinstance(data['graph'], str)
         assert isinstance(data['inserts'], list)
         assert isinstance(data['deletes'], list)
         self.graph = data['graph']
-        self.inserts = list(map(DeltaInsert, data['inserts']))
-        self.deletes = list(map(DeltaDelete, data['deletes']))
+        inserts = set(map(Triple, data['inserts']))
+        deletes = set(map(Triple, data['deletes']))
+        null_operations = inserts & deletes
+        self.inserts = list(inserts - null_operations)
+        self.deletes = list(deletes - null_operations)
 
     def __repr__(self):
         return "<UpdateData graph=%s inserts=%s deletes=%s>" % (self.graph, self.inserts, self.deletes)

--- a/sparql/triple.py
+++ b/sparql/triple.py
@@ -22,6 +22,10 @@ class Value:
         return "<%s type=%s value=%s datatype=%s>" % \
             (self.__class__.__name__, self.type, self.value, self.datatype)
 
+    def __hash__(self):
+        return hash((self.type, self.value, self.datatype))
+
+
 class Triple:
     def __init__(self, data):
         assert isinstance(data, dict)
@@ -37,3 +41,12 @@ class Triple:
 
     def __repr__(self):
         return "<%s s=%s p=%s o=%s>" % (self.__class__.__name__, self.s, self.p, self.o)
+
+    def __hash__(self):
+        return hash((hash(self.s), hash(self.p), hash(self.o)))
+
+    def __eq__(self, other):
+        if isinstance(other, Triple):
+            return hash(self) == hash(other)
+        else:
+            return False

--- a/sparql/triple.py
+++ b/sparql/triple.py
@@ -12,8 +12,7 @@ class Value:
     def __eq__(self, other):
         if isinstance(other, Value):
             return (
-                self.type is other.type and self.value is other.value and
-                self.datatype is other.datatype
+                self.type is other.type and self.value is other.value
             )
         else:
             return self.value == other
@@ -23,7 +22,7 @@ class Value:
             (self.__class__.__name__, self.type, self.value, self.datatype)
 
     def __hash__(self):
-        return hash((self.type, self.value, self.datatype))
+        return hash((self.type, self.value))
 
 
 class Triple:


### PR DESCRIPTION
@lordblendi This PR may break the current workflow.

1. The deltas received to the /update endpoint are filtered from "null operations". Which means: if the frontend writes restartRequested=true while restartRequested is already true, the operation will be filtered.

But... it should do the same for the scaling but it seems that the datatype is always different at every request. In other words, unless mu-cl-resources doesn't mix decimal and integers anymore or maybe if  we force the swarm admin to use only decimals. This particular issue will still be there.

2. This PR make a use of the restartRequested flag. It will only restart if the restartRequested flag becomes true and it resets the flag as soon as it starts restarting (valid for pipelines and services).