### PR TITLE
Upgraded aiodockerpy dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiodockerpy == 0.2.0
+aiodockerpy == 0.2.1
 aiohttp == 2.0.1
 aiosparql == 0.5.0
 python-dateutil == 2.6.0


### PR DESCRIPTION
This version restrict the Docker version to 2.1.0 and higher allowing
better compatibility with Docker Compose.