### PR TITLE
Added better healthcheck

### DIFF
--- a/muswarmadmin/__main__.py
+++ b/muswarmadmin/__main__.py
@@ -1,3 +1,6 @@
+raise Exception('bla')
+
+
 from aiohttp import web
 from os import environ as ENV
 from muswarmadmin.main import app
@@ -21,13 +24,13 @@ def pollAccumulate(count=0):
         r = requests.get(url, params=payload)
     except requests.RequestException:
         logger.warn('SPARQL endpoint not yet ready')
-        sleep(2)
-        if count == 10:
+        sleep(1)
+        if count >= 10:
             return False
         else:
             return pollAccumulate(count+1)
-    logger.info('SPARQL endpoint is ready')        
-    return True 
+    logger.info('SPARQL endpoint is ready')
+    return True
 
 try:
     while not pollAccumulate():

--- a/muswarmadmin/__main__.py
+++ b/muswarmadmin/__main__.py
@@ -10,19 +10,28 @@ import asyncio
 logger = logging.getLogger(__name__)
 loop = asyncio.get_event_loop()
 
-try:
+
+def pollAccumulate(count=0):
+    """
+    Poll the database until it is ready to answer queries
+    """
     payload = {'query': 'select distinct ?c where {[] a ?c } LIMIT 1'}
     url = ENV['MU_SPARQL_ENDPOINT']
-    getout = False
-    while not getout:
+    try:
         r = requests.get(url, params=payload)
-        if r.ok:
-            logger.info('SPARQL endpoint is ready')
-            getout = True
-        else:
-            logger.warn('SPARQL endpoint not yet ready')
+    except requests.RequestException:
+        logger.warn('SPARQL endpoint not yet ready')
         sleep(2)
+        if count == 10:
+            return False
+        else:
+            return pollAccumulate(count+1)
+    logger.info('SPARQL endpoint is ready')        
+    return True 
 
+try:
+    while not pollAccumulate():
+        continue
     web.run_app(app, port=(int(ENV['PORT']) if 'PORT' in ENV else None),
                 loop=loop)
 except (SystemExit, Exception):


### PR DESCRIPTION
When the requests.get() failed the exception was not being catched and retried. This will try it 10 times with a sleep of 2 seconds and if by then the DB is still down the microservice will fail.